### PR TITLE
Propagate failure

### DIFF
--- a/index.txt
+++ b/index.txt
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -euo pipefail
+
 #
 # Usage: curl https://pyenv.run | bash
 #
@@ -6,7 +8,7 @@
 #
 index_main() {
     set -e
-    curl -s -S -L https://raw.githubusercontent.com/pyenv/pyenv-installer/master/bin/pyenv-installer | bash
+    curl -s -S -L -f https://raw.githubusercontent.com/pyenv/pyenv-installer/master/bin/pyenv-installer | bash
 }
 
 index_main


### PR DESCRIPTION
If the install process fails, propagate that failure up so that a calling script can act/fail appropriately.

- `curl -f` means fail on error
- `set -e` means fail on error
- `set -o pipefail` means that if one command in a pipeline fails, the whole pipeline should fail
- `set -u` means fail on use of an uninitialized variable. There are no variables in this script, but this boilerplate is a good practice for all Bash scripts so I'm including it here anyway.

